### PR TITLE
[PLOP-558] Align test-suite with Template4

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,39 +37,38 @@ npm run test
 ```
 
 The `test`- and `output`-scripts are currently hardcoded to using `test/New.tp4`
-(and the accompanying `test/New.json` reference output).
+(and the accompanying `test/New.json` reference output). The test-suite used is
+nearly identical to the one provided as a smoke-test for the PHP-based
+[Template4](https://github.com/studyportals/Template4) implementation.
 
 ## Differences with PHP-based implementation
 
 The Jison-based parser is fully backwards-compatible with the Template4-syntax
 used by the PHP-based [Template4](https://github.com/studyportals/Template4)
-implementation.
+implementation, with _one_ significant exception:
 
-There are various enhancements though:
+- Several comparision operator aliasses supported by the PHP-based
+  implementation (`greater`, `gt` & `gte` &ndash; `smaller`, `lt` & `lte`
+  &ndash; `<>`) have been left out of the Jison-grammar. These aliasses will be
+  removed from the PHP-based implementation at its next major revision.
 
-- Support for quoted strings inside `condition`-statements.
-  - Includes support for empty strings (e.g. `""`) &ndash; in the PHP-based
-    implementation this is only possible by using `false` instead of an empty
-    string.
-  - Furthermore, this allows spaces to be used in condition arguments (e.g.
-    `"Hello World!"`).
-  - Support also extends to set-operations (`in`; `!in`) &ndash; allowing for
-    sets like `"Option 1 ", "Option 2"`.
-- Support for quoted strings inside `include`-statements &ndash; this makes it
-  possible to include files with spaces in their names.
-- Support for `!is` (together with `not`) &ndash; for parity with `!in`.
+There are also several (non-backwards compatible) enhancements:
+
+- Support for empty quoted strings inside `condition`-statements (e.g. `""`)
+  &ndash; in the PHP-based implementation this is only possible by using `false`
+  instead of an empty string.
 - The closing tag identifier is now optional (when provided, open-tag and
   closing-tag identifiers do still need to match) &ndash; it serves no purpose
   in the Jison-grammar.
-- Proper handling of whitespaces and comments. The old PHP-based parser would
-  eat all whitespaces and aggressively mangle HTML-comments. The new parser is
-  only concerned with HTML-comments that are part of Template4-tags
-  (`<!--[{..}]-->` and leaves other comments and whitespace untouched).
+- Proper handling of whitespaces and HTML-comments. The old PHP-based parser
+  would eat all whitespaces and aggressively mangle HTML-comments. The new
+  parser is only concerned with HTML-comments that are part of Template4-tags
+  (`<!--[{..}]-->`) and leaves other comments and whitespace untouched.
 
 📋 **TODO**: A second Jison-file (e.g. `template4-compat.jison`) should be
-provided that does _not_ allow any of the above enhancements. This should be
-used when using the Jison-based parser to validate templates fed into the
-PHP-based parser.
+provided that does _not_ allow any of the above enhancements (and perhaps
+includes the missing operator aliasses). This should be used when using the
+Jison-based parser to validate templates fed into the PHP-based parser.
 
 ## Caveats
 

--- a/template4.jison
+++ b/template4.jison
@@ -17,6 +17,9 @@
 <tp4>"include"          return 'TP4_INCLUDE'
 <tp4>"in"               return 'TP4_IN'
 <tp4>"is"               return 'TP4_IS'
+<tp4>"="                return 'TP4_EQ'
+<tp4>"<"                return 'TP4_LT'
+<tp4>">"                return 'TP4_GT'
 <tp4>"not"|"!"          return 'TP4_NOT'
 <tp4>"end"              return 'TP4_END'
 <tp4>"template"         return 'TP4_TEMPLATE'
@@ -190,13 +193,19 @@ tp4_string:   TP4_QUOTE TP4_QUOTE             { $$ = undefined }
             | TP4_QUOTE TP4_STRING TP4_QUOTE  { $$ = $TP4_STRING }
 ;
 
-tp4_op:   TP4_IS            { $$ = 'is' }
-        | TP4_NOT           { $$ = 'not' }
-        | TP4_NOT TP4_IS    { $$ = 'not' }
+tp4_op:   TP4_IS            { $$ = '==' }
+        | TP4_EQ TP4_EQ?    { $$ = '==' }
+        | TP4_NOT           { $$ = '!=' }
+        | TP4_NOT TP4_IS    { $$ = '!=' }
+        | TP4_NOT TP4_EQ    { $$ = '!=' }
+        | TP4_LT            { $$ =  '<' }
+        | TP4_LT TP4_EQ     { $$ = '<=' }
+        | TP4_GT            { $$ =  '>' }
+        | TP4_GT TP4_EQQ    { $$ = '>=' }
 ;
 
-tp4_setop:  TP4_IN          { $$ = 'is' }
-          | TP4_NOT TP4_IN  { $$ = 'not' }
+tp4_setop:  TP4_IN          { $$ =  'in' }
+          | TP4_NOT TP4_IN  { $$ = '!in' }
 ;
 
 tp4_as_name:  // Empty

--- a/test/New.json
+++ b/test/New.json
@@ -1,7 +1,7 @@
 [
   {
     "t": "html",
-    "d": "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n<head>\r\n  <meta charset=\"UTF-8\">\r\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\r\n  <title>New</title>\r\n</head>\r\n<body>\r\n\r\n\t<h1>"
+    "d": "<!DOCTYPE html>\r\n<html lang=\"en\">\r\n<head>\r\n  <meta charset=\"UTF-8\">\r\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\r\n  <title>Template4 Test</title>\r\n</head>\r\n<body>\r\n\r\n\t<h1>"
   },
   { "t": "var", "n": "header1", "a": { "raw": false } },
   { "t": "html", "d": "</h1>\r\n\r\n\t<h2>Replace &amp; Replace Raw</h2>\r\n\t<p>" },
@@ -13,7 +13,7 @@
     "t": "if",
     "n": "in_set",
     "d": ["1", "2", "3"],
-    "o": "is",
+    "o": "in",
     "c": [{ "t": "html", "d": "\r\n\t\t<p>In 1, 2 or 3!</p>\r\n\t" }]
   },
   { "t": "html", "d": "\r\n\r\n\t" },
@@ -21,7 +21,7 @@
     "t": "if",
     "n": "in_set",
     "d": ["1", "2", "3"],
-    "o": "not",
+    "o": "!in",
     "c": [
       {
         "t": "html",
@@ -34,7 +34,7 @@
     "t": "if",
     "n": "quoted_if",
     "d": "Hello World!",
-    "o": "is",
+    "o": "==",
     "c": [{ "t": "html", "d": "\r\n\t\t<p>Quoted if-statement</p>\r\n\t" }]
   },
   { "t": "html", "d": "\r\n\r\n\t" },
@@ -42,7 +42,7 @@
     "t": "if",
     "n": "quoted_set",
     "d": ["Hello World!", "Foo", ""],
-    "o": "is",
+    "o": "in",
     "c": [
       {
         "t": "html",
@@ -55,7 +55,7 @@
     "t": "if",
     "n": "in_set2",
     "d": ["foo", "bar"],
-    "o": "is",
+    "o": "in",
     "c": [
       { "t": "html", "d": "\r\n\t\t<p>Either foo or bar: <strong>" },
       { "t": "var", "n": "in_set2", "a": { "raw": false } },
@@ -69,7 +69,7 @@
   { "t": "var", "n": "random_string", "a": { "raw": false } },
   {
     "t": "html",
-    "d": "</strong>.\r\n\t\t<br/>\r\n\t\tHere are some literal [, ], { and } characters; [Hello] {World}!\r\n\t</p>\r\n\r\n\t<h1>Recursive Repeater</h1>\r\n\r\n\t<p>The output for the <strong>correct</strong> approach is displayed below. The\r\n\tincorrect (c.q. wrong) approach is executed on a clone of the template to\r\n\tprevent it from polluting the template, which would cause problems with further\r\n\ttests.</p>\r\n\r\n\t"
+    "d": "</strong>.\r\n\t\t<br/>\r\n\t\tHere are some literal [, ], { and } characters; [Hello] {World}!\r\n\t</p>\r\n\r\n\t<h1>Recursive Repeater</h1>\r\n\r\n\t"
   },
   {
     "t": "section",
@@ -134,7 +134,7 @@
                 "t": "if",
                 "n": "test_me",
                 "d": "false",
-                "o": "is",
+                "o": "==",
                 "c": [
                   { "t": "html", "d": "\r\n\t\t\t\t\t" },
                   {
@@ -160,7 +160,7 @@
                 "t": "if",
                 "n": "lipsum_bold",
                 "d": "true",
-                "o": "is",
+                "o": "==",
                 "c": [{ "t": "html", "d": "style=\"font-weight:bold;\"" }]
               },
               {
@@ -172,25 +172,34 @@
           { "t": "html", "d": "\r\n\r\n\t\t" }
         ]
       },
+      { "t": "html", "d": "\r\n\r\n\t\t" },
+      {
+        "t": "include",
+        "d": [
+          {
+            "t": "html",
+            "d": "<p>\r\n  Include template with <strong><em>spaces!!!</em></strong> "
+          },
+          { "t": "var", "n": "test", "a": { "raw": false } },
+          { "t": "html", "d": ".\r\n  </br>\r\n  Hello World!\r\n</p>\r\n" }
+        ]
+      },
       { "t": "html", "d": "\r\n\r\n\t" }
     ]
   },
-  {
-    "t": "html",
-    "d": "\r\n\r\n\t<p>\r\n  Include template with <strong><em>spaces!!!</em></strong> [{var test}].\r\n  </br>\r\n  Hello World!\r\n</p>\r\n\r\n\r\n\t"
-  },
+  { "t": "html", "d": "\r\n\r\n\t" },
   {
     "t": "if",
     "n": "lipsum_bold",
     "d": "",
-    "o": "not",
+    "o": "!=",
     "c": [
       { "t": "html", "d": "\r\n\t\t<p " },
       {
         "t": "if",
         "n": "lipsum_bold",
         "d": "true",
-        "o": "is",
+        "o": "==",
         "c": [{ "t": "html", "d": "style=\"font-weight:bold;\"" }]
       },
       {

--- a/test/New.tp4
+++ b/test/New.tp4
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>New</title>
+  <title>Template4 Test</title>
 </head>
 <body>
 
@@ -42,11 +42,6 @@
 	</p>
 
 	<h1>Recursive Repeater</h1>
-
-	<p>The output for the <strong>correct</strong> approach is displayed below. The
-	incorrect (c.q. wrong) approach is executed on a clone of the template to
-	prevent it from polluting the template, which would cause problems with further
-	tests.</p>
 
 	[{section ListWrapper}]
 
@@ -98,9 +93,9 @@
 
 		[{section end}]
 
-	[{section Test end}]
+		[{include template "Include with Spaces.tp4"}]
 
-	[{include "Include with Spaces.tp4"}]
+	[{section Test end}]
 
 	[{if lipsum_bold !is ""}]
 		<p [{if lipsum_bold is true}]style="font-weight:bold;"[{if end}]>


### PR DESCRIPTION
PLOP-558 &ndash; see also https://github.com/studyportals/Template4/pull/4

This aligns the test-suite used by template4-parser with the smoke-tests used by Template4.

It furthermore adds several missing comparison operators (and introduces a slight backwards-compatibility issue by not implementing all aliases &ndash; `README.md` has all the details).